### PR TITLE
Add red box start for reaction game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# Tempnixk.github.io
+# Mini Games
+
+This site contains small browser games built with HTML and JavaScript. Currently it includes:
+
+- **Guess the Number**: try to guess a random number with an attempt counter and best score.
+- **Reaction Time Test**: start by clicking the red box and then hit it again as soon as it turns green. Your score is judged from 70ms (best) to over 250ms (worst).
+
+More games may be added over time.

--- a/index.html
+++ b/index.html
@@ -2,34 +2,139 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>Guess the Number Game</title>
+<title>Mini Games</title>
 <style>
   body { font-family: Arial, sans-serif; max-width: 600px; margin: 40px auto; text-align: center; }
   input { margin: 10px; padding: 8px; }
+  .hint { color: #555; margin-top: 5px; }
+  .game { border: 1px solid #ddd; padding: 20px; margin: 20px 0; }
+  #reaction-box {
+    width: 200px;
+    height: 200px;
+    margin: 20px auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: red;
+    cursor: pointer;
+    color: #fff;
+    user-select: none;
+  }
 </style>
 </head>
 <body>
-<h1>Guess the Number!</h1>
-<p>I'm thinking of a number between 1 and 100.</p>
-<input type="number" id="guess" />
-<button onclick="makeGuess()">Guess</button>
-<p id="result"></p>
+<h1>Mini Games</h1>
+
+<section id="guessing-game" class="game">
+  <h2>Guess the Number</h2>
+  <p>I'm thinking of a number between 1 and 100.</p>
+  <input type="number" id="guess" />
+  <button onclick="makeGuess()">Guess</button>
+  <button onclick="resetGame()">Reset</button>
+  <p id="result"></p>
+  <p id="attempts"></p>
+  <p id="best"></p>
+</section>
+
+<section id="reaction-game" class="game">
+  <h2>Reaction Time Test</h2>
+  <p>Click the box as soon as it turns green.</p>
+  <div id="reaction-box">Start</div>
+  <p id="reaction-result"></p>
+</section>
+
 <script>
   let number = Math.floor(Math.random() * 100) + 1;
+  let attempts = 0;
+  const bestScore = localStorage.getItem('bestScore');
+  if (bestScore) {
+    document.getElementById('best').textContent = `Best Score: ${bestScore} guesses`;
+  }
+  function updateAttempts() {
+    document.getElementById('attempts').textContent = `Attempts: ${attempts}`;
+  }
   function makeGuess() {
     const guess = parseInt(document.getElementById('guess').value, 10);
     if (!guess) {
       document.getElementById('result').textContent = 'Please enter a number.';
       return;
     }
+    attempts++;
+    updateAttempts();
     if (guess === number) {
-      document.getElementById('result').textContent = 'Correct! Refresh to play again.';
+      document.getElementById('result').textContent = 'Correct!';
+      const best = localStorage.getItem('bestScore');
+      if (!best || attempts < best) {
+        localStorage.setItem('bestScore', attempts);
+        document.getElementById('best').textContent = `Best Score: ${attempts} guesses`;
+      }
     } else if (guess < number) {
       document.getElementById('result').textContent = 'Too low! Try again.';
     } else {
       document.getElementById('result').textContent = 'Too high! Try again.';
     }
   }
+  function resetGame() {
+    number = Math.floor(Math.random() * 100) + 1;
+    attempts = 0;
+    updateAttempts();
+    document.getElementById('result').textContent = '';
+    document.getElementById('guess').value = '';
+  }
+  updateAttempts();
+
+  // Reaction Time Game
+  let reactionStart = 0;
+  let reactionTimeout;
+  let state = 'ready';
+  const box = document.getElementById('reaction-box');
+
+  function evaluate(time) {
+    if (time <= 70) {
+      return `Awesome! ${time} ms`;
+    } else if (time <= 100) {
+      return `Great! ${time} ms`;
+    } else if (time <= 150) {
+      return `Good! ${time} ms`;
+    } else if (time <= 200) {
+      return `Not bad. ${time} ms`;
+    } else if (time <= 250) {
+      return `Slow! ${time} ms`;
+    }
+    return `Too slow! ${time} ms`;
+  }
+
+  function startWaiting() {
+    document.getElementById('reaction-result').textContent = '';
+    box.textContent = '';
+    const delay = Math.random() * 2000 + 1000; // 1-3 seconds
+    reactionTimeout = setTimeout(() => {
+      state = 'active';
+      box.style.backgroundColor = 'green';
+      reactionStart = Date.now();
+    }, delay);
+  }
+
+  box.addEventListener('click', () => {
+    if (state === 'ready') {
+      state = 'waiting';
+      startWaiting();
+    } else if (state === 'waiting') {
+      clearTimeout(reactionTimeout);
+      document.getElementById('reaction-result').textContent = 'Too soon!';
+      state = 'ready';
+      box.style.backgroundColor = 'red';
+      box.textContent = 'Start';
+    } else if (state === 'active') {
+      const reactionTime = Date.now() - reactionStart;
+      document.getElementById('reaction-result').textContent = evaluate(reactionTime);
+      state = 'ready';
+      box.style.backgroundColor = 'red';
+      box.textContent = 'Start';
+      clearTimeout(reactionTimeout);
+      reactionStart = 0;
+    }
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- improve Reaction Time Test: red box acts as start and stays visible
- grade reaction time with messages for 70ms, 100ms, 150ms, 200ms, 250ms and above
- update README instructions for playing the reaction test

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683ff8eaa5188331a458b5ba60fdfe80